### PR TITLE
Fix for platforms always having"scale" attribute

### DIFF
--- a/FullScreenMario.js
+++ b/FullScreenMario.js
@@ -2101,6 +2101,7 @@ var FullScreenMario = (function(GameStartr) {
      * @param {Thing} thing
      */
     function spawnMoveFloating(thing) {
+        console.log("Moving", thing.title);
         // Make sure thing.begin <= thing.end
         thing.EightBitter.setMovementEndpoints(thing);
         
@@ -7731,7 +7732,7 @@ var FullScreenMario = (function(GameStartr) {
                 "x": x - (widthLeft / 2), 
                 "y": y - dropLeft, 
                 "width": widthLeft,
-                "scale": true,
+                "inScale": true,
                 "tension": (dropLeft - 1.5) * unitsize,
                 "onThingAdd": spawnScalePlatform,
                 "collectionName": collectionName,
@@ -7742,7 +7743,7 @@ var FullScreenMario = (function(GameStartr) {
                 "x": x + between - (widthRight / 2),
                 "y": y - dropRight, 
                 "width": widthRight,
-                "scale": true,
+                "inScale": true,
                 "tension": (dropRight - 1.5) * unitsize,
                 "onThingAdd": spawnScalePlatform,
                 "collectionName": collectionName,

--- a/settings/objects.js
+++ b/settings/objects.js
@@ -785,7 +785,7 @@
                     "falling": {
                         "movement": FullScreenMario.prototype.moveFalling
                     },
-                    "scale": {
+                    "inScale": {
                         "movement": FullScreenMario.prototype.movePlatformScale
                     }
                 }


### PR DESCRIPTION
The macro now places them as having "inScale", so as to not conflict
with the rendering engine's .scale.