### PR TITLE
Fix digitsize computation

### DIFF
--- a/Source/References/PixelRendr-0.2.0.ts
+++ b/Source/References/PixelRendr-0.2.0.ts
@@ -894,7 +894,10 @@ module PixelRendr {
                             // Isolate and split the new palette's numbers
                             paletteref = this.getPaletteReference(colors.slice(loc + 1, nixloc).split(","));
                             loc = nixloc + 1;
-                            digitsize = 1;
+                            digitsize = 0;
+                            for (var n: number = Object.keys(paletteref).length; n >= 1; n /= 10) {
+                                ++digitsize;
+                            }
                         } else {
                             // Otherwise go back to default
                             paletteref = this.getPaletteReference(this.paletteDefault);

--- a/Source/References/PixelRendr-0.2.0.ts
+++ b/Source/References/PixelRendr-0.2.0.ts
@@ -1310,7 +1310,11 @@ module PixelRendr {
          *                  any index of the palettte).
          */
         private getDigitSize(palette: any[]): number {
-            return Math.floor(Math.log(palette.length) / Math.LN10) + 1;
+            var digitsize: number = 0;
+            for (var n: number = palette.length; n >= 1; n /= 10) {
+                ++digitsize;
+            }
+            return digitsize;
         }
 
         /**


### PR DESCRIPTION
Apply patches from https://github.com/FullScreenShenanigans/PixelRendr/pull/11.
