### PR TITLE
Made mapEntrancePipeVertical play theme manually

### DIFF
--- a/Source/FullScreenMario.ts
+++ b/Source/FullScreenMario.ts
@@ -7084,7 +7084,7 @@ module FullScreenMario {
             FSM.AudioPlayer.addEventListener(
                 "Pipe",
                 "ended",
-                function () {
+                function (): void {
                     FSM.AudioPlayer.playTheme();
                 });
 

--- a/Source/FullScreenMario.ts
+++ b/Source/FullScreenMario.ts
@@ -7076,18 +7076,17 @@ module FullScreenMario {
             }
 
             FSM.addPlayer(
-                (
-                    location.entrance.left
-                    + FSM.player.width * FSM.unitsize / 2
-                    ),
-                (
-                    location.entrance.top
-                    + FSM.player.height * FSM.unitsize
-                    )
-                );
+                location.entrance.left + FSM.player.width * FSM.unitsize / 2,
+                location.entrance.top + FSM.player.height * FSM.unitsize);
 
             FSM.animatePlayerPipingStart(FSM.player);
             FSM.AudioPlayer.play("Pipe");
+            FSM.AudioPlayer.addEventListener(
+                "Pipe",
+                "ended",
+                function () {
+                    FSM.AudioPlayer.playTheme();
+                });
 
             FSM.TimeHandler.addEventInterval(
                 function (): boolean {


### PR DESCRIPTION
animatePlayerPipingStart was pausing it. It should be played on the
"Pipe"::"ended" event.

Also fixed the silly indentation/parenthesis for FSM.addPlayer...

Followup to PR #300.

Wow, 300 pull requests!